### PR TITLE
Include <cinttypes> for PRIi64 definition

### DIFF
--- a/minisat/simp/Main.cc
+++ b/minisat/simp/Main.cc
@@ -18,6 +18,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+#include <cinttypes>
 #include <errno.h>
 
 #include <signal.h>

--- a/minisat/utils/Options.cc
+++ b/minisat/utils/Options.cc
@@ -17,6 +17,8 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
+#include <cinttypes>
+
 #include "minisat/mtl/Sort.h"
 #include "minisat/utils/Options.h"
 #include "minisat/utils/ParseUtils.h"


### PR DESCRIPTION
Main and Options rely on this definition being available, or
worked-around for MSVC [1]. However, it is only guaranteed to be
availble if cinttypes is included [2].

[1] https://stackoverflow.com/questions/25460573/what-is-the-msvc-compatible-version-of-format-specifier-qi

[2] Format macro constants
      Defined in header <cinttypes>
      Format constants for the std::fprintf family of functions
    https://en.cppreference.com/w/cpp/types/integer